### PR TITLE
fix: add the whole dist directory to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "test": "test"
   },
   "files": [
-    "dist/**/*.js",
-    "dist/**/*.ts",
+    "dist",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Source maps were not exported.

It creates this kind of issue:
```
Failed to parse source map from 'node_modules/jsonref/dist/errors.js.map' file: Error: ENOENT: no such file or directory
```

Adding the whole `dist` directory to `files` in `package.json` makes sure everything is exported as expected.